### PR TITLE
feat: refine reading progress bar animation

### DIFF
--- a/src/components/ReadingProgressBar.tsx
+++ b/src/components/ReadingProgressBar.tsx
@@ -17,12 +17,14 @@ export function ReadingProgressBar({ withinHeader = false, active = true }: Read
     <div className={containerClass} aria-hidden="true">
       <div
         className={[
-          "h-full bg-foreground will-change-[width]",
-          active ? "transition-[width] duration-xxs ease-linear" : "transition-none",
+          "h-full bg-foreground origin-left will-change-transform",
+          active
+            ? "md:transition-transform md:duration-75 md:ease-linear"
+            : "transition-none",
           active ? (progress > 0 ? "opacity-100" : "opacity-0") : "opacity-0",
           "motion-reduce:transition-none",
         ].join(" ")}
-        style={{ width: `${active ? progress * 100 : 0}%` }}
+        style={{ transform: `scaleX(${active ? progress : 0})` }}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- switch bar fill to GPU-friendly scaleX transform for smoother updates
- drop mobile transitions and keep a short desktop transition

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68baecac97f0832b944023d0538f5db9