### PR TITLE
feat: replace fonts with Geist Mono

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { buildTitle, canonical, defaultDescription, defaultOgImage } from '../../src/lib/seo'
 import Layout from '../../src/components/Layout'
+import { TypingHeading } from '@/components/TypingHeading'
 
 export const metadata: Metadata = {
   title: buildTitle('About'),
@@ -35,7 +36,9 @@ export default function AboutPage() {
   return (
     <Layout>
       <div className="mx-auto max-w-3xl py-10">
-        <h1 className="text-2xl md:text-3xl font-medium mb-6">About Sandheep Rajkumar</h1>
+        <TypingHeading className="text-2xl md:text-3xl font-medium mb-6">
+          About Sandheep Rajkumar
+        </TypingHeading>
         <p className="text-base md:text-lg text-foreground/80">
           Work in progress. This page will contain information about me and my interests.
         </p>

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -5,6 +5,7 @@ import Layout from '../../src/components/Layout'
 import YearSection from '../../src/components/YearSection'
 import { articles } from '../../src/data/articles'
 import { Separator } from '../../src/components/ui/separator'
+import { TypingHeading } from '@/components/TypingHeading'
 
 export const metadata: Metadata = {
   title: buildTitle('Writings'),
@@ -62,7 +63,9 @@ export default function BlogPage() {
   return (
     <Layout>
       <div className="mx-auto max-w-2xl py-10">
-        <h1 className="text-2xl md:text-3xl font-medium mb-10 text-theme">Writings</h1>
+        <TypingHeading className="text-2xl md:text-3xl font-medium mb-10 text-theme">
+          Writings
+        </TypingHeading>
         <div>
           {sortedYears.map((year, idx) => (
             <React.Fragment key={year}>

--- a/app/commonplace/page.tsx
+++ b/app/commonplace/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next'
 import { buildTitle, canonical, defaultOgImage } from '../../src/lib/seo'
 import Layout from '../../src/components/Layout'
 import { Separator } from '../../src/components/ui/separator'
+import { TypingHeading } from '@/components/TypingHeading'
 
 interface Link {
   title: string;
@@ -89,7 +90,9 @@ export default function CommonplacePage() {
   return (
     <Layout>
       <div className="mx-auto max-w-2xl py-10">
-        <h1 className="text-2xl md:text-3xl font-medium mb-10">Commonplace Book</h1>
+        <TypingHeading className="text-2xl md:text-3xl font-medium mb-10">
+          Commonplace Book
+        </TypingHeading>
         <div className="space-y-0">
           {links.map((link, index) => (
             <React.Fragment key={index}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -409,3 +409,13 @@
     transition-timing-function: var(--ease-theme);
   }
 }
+
+@keyframes typing {
+  from { width: 0 }
+  to { width: var(--characters) }
+}
+
+@keyframes blink {
+  0%,100% { border-color: transparent }
+  50% { border-color: currentColor }
+}

--- a/src/components/ServerArticleDetail.tsx
+++ b/src/components/ServerArticleDetail.tsx
@@ -6,6 +6,7 @@ import ReactMarkdown from 'react-markdown';
 import { OptimizedImage } from './OptimizedImage';
 import { Separator } from "@/components/ui/separator";
 import Layout from './Layout';
+import { TypingHeading } from '@/components/TypingHeading';
 
 interface ServerArticleDetailProps {
   id: string;
@@ -44,7 +45,9 @@ export default async function ServerArticleDetail({ id }: ServerArticleDetailPro
     <Layout>
       <article className="mx-auto max-w-3xl px-4">
         <div className="mt-8">
-          <h1 className="text-3xl md:text-4xl font-bold mb-4">{article.title}</h1>
+          <TypingHeading className="text-3xl md:text-4xl font-bold mb-4">
+            {article.title}
+          </TypingHeading>
           <div className="mb-6">
             <span className="text-sm uppercase tracking-wider text-foreground/60">
               SANDHEEP RAJKUMAR | {article.fullDate}

--- a/src/components/TypingHeading.tsx
+++ b/src/components/TypingHeading.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+
+interface TypingHeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
+  children: string
+}
+
+export function TypingHeading({ children, className, ...props }: TypingHeadingProps) {
+  const characters = children.length
+  return (
+    <h1
+      className={cn(
+        'inline-block whitespace-nowrap overflow-hidden border-r border-current align-top',
+        className
+      )}
+      style={{
+        '--characters': `${characters}ch`,
+        animation: `typing 1.5s steps(${characters}, end) forwards, blink 1s step-end infinite`
+      } as React.CSSProperties}
+      {...props}
+    >
+      {children}
+    </h1>
+  )
+}
+
+export default TypingHeading


### PR DESCRIPTION
## Summary
- adopt Geist Mono as the global font
- remove Playfair and Lexend usage and config
- use provided GeistMono constant instead of invoking it
- silence triple-slash lint warning in generated Next types
- add typewriter animation for page headings

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbd0fbc5c4832b870ff9a4a24b5e4a